### PR TITLE
add missing #include for std::forEach()

### DIFF
--- a/EventEmitter.hpp
+++ b/EventEmitter.hpp
@@ -15,6 +15,7 @@
 #include <tuple>
 #include <type_traits>
 #include <vector>
+#include <algorithm> //std::forEach()
 #include <Functor.hpp>
 
 class EventEmitter {


### PR DESCRIPTION
getting errors:
EventEmitter.hpp:33:9: error: ‘for_each’ is not a member of ‘std’
         std::for_each(events.begin(), events.end(), [](std::pair<std::string, s
         ^
EventEmitter.hpp:35:13: error: ‘for_each’ is not a member of ‘std’
             std::for_each(listeners.begin(), listeners.end(), [](EventListener&
             ^
EventEmitter.hpp:88:9: error: ‘for_each’ is not a member of ‘std’
         std::for_each(once_listener.begin(), once_listener.end(), [&listeners](
         ^

The fix is to add #include <algorithm>